### PR TITLE
fix: Linux和MacOS上写入文件0字节问题

### DIFF
--- a/edgeTTS/edgeTTS.go
+++ b/edgeTTS/edgeTTS.go
@@ -83,7 +83,7 @@ func NewTTS(args Args) *EdgeTTS {
 		}
 	}
 	tts := NewCommunicate().WithVoice(args.Voice).WithRate(args.Rate).WithVolume(args.Volume)
-	file, err := os.OpenFile(args.WriteMedia, os.O_APPEND|os.O_CREATE|os.O_TRUNC, 0644)
+	file, err := os.OpenFile(args.WriteMedia, os.O_WRONLY|os.O_APPEND|os.O_TRUNC|os.O_CREATE, 0644)
 	if err != nil {
 		log.Fatalf("Failed to open file: %v\n", err)
 		return nil
@@ -128,7 +128,9 @@ func (eTTS *EdgeTTS) Speak() {
 
 	go eTTS.communicator.allocateTask(eTTS.texts)
 	eTTS.communicator.createPool()
-	for _, text := range eTTS.texts {
-		eTTS.outCome.Write(text.speechData)
+		_, err := eTTS.outCome.Write(text.speechData)
+		if err != nil {
+			log.Fatalln("Failed to write to file:", err)
+		}
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/surfaceyu/edge-tts-go
+module github.com/baohuiming/edge-tts-go
 
 go 1.20
 

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@
 
 To install it, run the following command:
 
-    $ go install github.com/surfaceyu/edge-tts-go
+    $ go install github.com/baohuiming/edge-tts-go
 
 ## Usage
 

--- a/version.go
+++ b/version.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 )
 
-const Version = "0.1.0"
+const Version = "0.1.1"
 
 func VersionInfo() (int, int, int) {
 	versionInfo := strings.Split(Version, ".")


### PR DESCRIPTION
现有代码在Linux和MacOS上运行，可能会出现写入的mp3文件为0字节的情况，经检查是打开文件时可能会缺乏写入权限，因此添加只写权限和相应的错误处理代码